### PR TITLE
Nuevo Gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,15 @@
 *.pidb
 *.booproj
 *.svd
-
+*.consulo/
+*/.vs/
+*.pbd
 
 # Unity3D generated meta files
 *.pidb.meta
 
 # Unity3D Generated File On Crash Reports
 */sysinfo.txt
+# Builds
+*.apk
+*.unitypackage


### PR DESCRIPTION
Se modifico el Gitignore que le he pasado a isma para evitar  que suba ahora .apk y .unitypackague ademàs de otros archivos innecesarios.